### PR TITLE
Trying to specify python version for RTD

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
 # https://github.com/conda/conda/issues/5003
 - nodefaults
 dependencies:
+- python=3.9
 - pip
 - gdal
 - pip:


### PR DESCRIPTION
Quick fix to get RTD working again. Adds python as a dependency in the `environment.yml` file. As Emily noted on Slack:

>The python version should be set to 3.8 by [.readthedocs.yml](https://github.com/natcap/invest.users-guide/blob/release/3.12.0/.readthedocs.yml) , but it might not be working because that syntax is deprecated (https://docs.readthedocs.io/en/stable/config-file/v2.html#python-version). Annoying that they don’t give us a deprecation warning!