### PR TITLE
Updating the citation and build information.

### DIFF
--- a/source/en/index.rst
+++ b/source/en/index.rst
@@ -14,10 +14,11 @@ InVEST User Guide
 
 .. figure:: index/main_image.png
 
-**Suggested citation**: Natural Capital Project, |commit_year|. InVEST |version|
-User’s Guide. Stanford University, University of Minnesota, Chinese Academy
+**Suggested citation**: Natural Capital Project, |commit_year|. InVEST |version|.
+Stanford University, University of Minnesota, Chinese Academy
 of Sciences, The Nature Conservancy, World Wildlife Fund, Stockholm
 Resilience Centre and the Royal Swedish Academy of Sciences.
+https://naturalcapitalproject.stanford.edu/software/invest
 
 **Contributors**\*:
 

--- a/source/en/index.rst
+++ b/source/en/index.rst
@@ -14,7 +14,7 @@ InVEST User Guide
 
 .. figure:: index/main_image.png
 
-**Suggested citation**: Natural Capital Project, 2022. InVEST |version|
+**Suggested citation**: Natural Capital Project, |commit_year|. InVEST |version|
 User’s Guide. Stanford University, University of Minnesota, Chinese Academy
 of Sciences, The Nature Conservancy, World Wildlife Fund, Stockholm
 Resilience Centre and the Royal Swedish Academy of Sciences.


### PR DESCRIPTION
This PR updates the suggested citation in response to [a recent discussion on slack](https://stanford-natcap.slack.com/archives/CECFUU1DW/p1686941898377019). 

Specific changes are:

* Citation year is now pulled from the year of the latest commit.
* Citation version is the last git-tagged release.
* Git build information is moved to the HTML page footer.
* Download page link added

The git build information still has all the detail it always did, it's just now hidden.