### PR TITLE
Standardize LULC column names to `lucode`

### DIFF
--- a/source/en/coastal_blue_carbon.rst
+++ b/source/en/coastal_blue_carbon.rst
@@ -554,7 +554,7 @@ Inputs
 
   Columns:
 
-  - :investspec:`coastal_blue_carbon.preprocessor lulc_lookup_table_path.columns.code`
+  - :investspec:`coastal_blue_carbon.preprocessor lulc_lookup_table_path.columns.lucode`
   - :investspec:`coastal_blue_carbon.preprocessor lulc_lookup_table_path.columns.lulc-class`
   - :investspec:`coastal_blue_carbon.preprocessor lulc_lookup_table_path.columns.is_coastal_blue_carbon_habitat`
 
@@ -600,7 +600,7 @@ to the optional user-defined Suffix input to the model.
 - **carbon_pool_transient_template_[Suffix].csv**: CSV (.csv, Comma Separated
   Value) format table, mapping each LULC type to impact and accumulation
   information. You must fill in all columns of this table except the
-  'lulc-class' and 'code' columns, which will be pre-populated by the model.
+  'lulc-class' and 'lucode' columns, which will be pre-populated by the model.
   See *Step 2. The Main Model* for more information. Accumulation units are
   (Megatonnes of CO\ :sub:`2` e/ha-yr), half-life is in integer years, and
   disturbance is in integer percent.
@@ -608,7 +608,7 @@ to the optional user-defined Suffix input to the model.
  The edited table is used as input to the main Coastal Blue Carbon model as the **Biophysical Table**.
 
   ==========  ==========  ===============  ============  ==============  =================  ==========================  ==========================  ===========================  ===========================  ==============  =======================  =======================  ========================  ========================  ==========================
-  code        lulc-class  biomass-initial  soil-initial  litter-initial  biomass-half-life  biomass-low-impact-disturb  biomass-med-impact-disturb  biomass-high-impact-disturb  biomass-yearly-accumulation  soil-half-life  soil-low-impact-disturb  soil-med-impact-disturb  soil-high-impact-disturb  soil-yearly-accumulation  litter-yearly-accumulation
+  lucode      lulc-class  biomass-initial  soil-initial  litter-initial  biomass-half-life  biomass-low-impact-disturb  biomass-med-impact-disturb  biomass-high-impact-disturb  biomass-yearly-accumulation  soil-half-life  soil-low-impact-disturb  soil-med-impact-disturb  soil-high-impact-disturb  soil-yearly-accumulation  litter-yearly-accumulation
   ==========  ==========  ===============  ============  ==============  =================  ==========================  ==========================  ===========================  ===========================  ==============  =======================  =======================  ========================  ========================  ==========================
   <int>       <lulc1>
   <int>       <lulc2>
@@ -644,7 +644,7 @@ Inputs
 
   Columns:
 
-  - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.code`
+  - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.lucode`
   - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.lulc-class`
   - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.biomass-initial`
   - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.soil-initial`

--- a/source/en/habitat_quality.rst
+++ b/source/en/habitat_quality.rst
@@ -178,7 +178,7 @@ Columns:
   Hypothetical study with three threats for both current and future scenarios. Agriculture (*Agric* in the table) degrades habitat over a larger distance than roads do, and has a greater overall magnitude of impact. Further, paved roads (*Paved_rd*) attract more traffic than dirt roads (*Dirt_rd*) and thus are more destructive to nearby habitat than dirt roads. Filepaths may be absolute or relative to the Threat data table. In this instance the current threats are found in the same directory as the table and the future threats are found in a sub directory adjacent to the Threat data table called *future*. Baseline threat filepaths are left blank because we do not have threat rasters for that scenario OR we have not included the baseline LULC in our model run altogether.
 
   ========   ========  ======  =========== ============ =================  =======================
-  THREAT     MAX_DIST  WEIGHT  DECAY        BASE_PATH     CUR_PATH         FUT_PATH
+  threat     max_dist  weight  decay       base_path    cur_path           fut_path
   ========   ========  ======  =========== ============ =================  =======================
   Dirt_rd    2         0.1     linear                   dirt_rd.tif        future/dirt_rd_fut.tif
   Paved_rd   4         0.4     exponential              paved_rd.tif       future/paved_rd_fut.tif
@@ -199,21 +199,22 @@ Columns:
 
   Columns:
 
-  - :investspec:`habitat_quality sensitivity_table_path.columns.lulc`
+  - :investspec:`habitat_quality sensitivity_table_path.columns.lucode`
+  - :investspec:`habitat_quality sensitivity_table_path.columns.name`
   - :investspec:`habitat_quality sensitivity_table_path.columns.habitat` This is :math:`H_j` in the equations above. If you want to simply classify each LULC as habitat or not without reference to any particular species group then use 0s and 1s where a 1 indicates habitat. Otherwise, if sufficient information is available on a species group's habitat preferences, assign the LULC a relative habitat suitability score between 0 and 1 where 1 indicates the highest habitat suitability. For example, a grassland songbird may prefer a native prairie habitat above all other habitat types (prairie is given a "HABITAT" score of 1 for grassland birds), but will also use a managed hayfield or pasture if prairie is not available (managed hayfield and pasture are given a "HABITAT" score of 0.5 for grassland birds).
 
   - :investspec:`habitat_quality sensitivity_table_path.columns.[THREAT]` Even if the LULC is not considered habitat, do not leave its sensitivity to each threat as Null or blank, instead enter a 0.
 
   *Example:* A hypothetical study with four LULC types and three threats. In this example we treat Closed Woodland and Forest Mosaic as (absolute) habitat and Bare Soil and Cultivation as (absolute) non-habitat. Forest mosaic is the most sensitive (least resistant) habitat type, and is more sensitive to dirt roads (DIRT_RD, value 0.9) than paved roads (PAVED_RD, value 0.5) or agriculture (AGRIC value 0.8). We enter 0s across all threats for the two developed land covers, Bare Soil and Cultivation, since they are not habitat.
 
-  ====    =============== ======= ======= ==========  =========
-  LULC    NAME            HABITAT AGRIC   PAVED_RD    DIRT_RD
-  ====    =============== ======= ======= ==========  =========
-  1       Bare Soil       0       0       0           0
-  2       Closed Woodland 1       0.5     0.2         0.4
-  3       Cultivation     0       0       0           0
-  4       Forest Mosaic   1       0.8     0.8         0.5
-  ====    =============== ======= ======= ==========  =========
+  ======    =============== ======= ======= ==========  =========
+  lucode    name            habitat agric   paved_rd    dirt_rd
+  ======    =============== ======= ======= ==========  =========
+  1         Bare Soil       0       0       0           0
+  2         Closed Woodland 1       0.5     0.2         0.4
+  3         Cultivation     0       0       0           0
+  4         Forest Mosaic   1       0.8     0.8         0.5
+  ======    =============== ======= ======= ==========  =========
 
 - :investspec:`habitat_quality access_vector_path` Polygons with minimum accessibility (e.g., strict nature reserves, well protected private lands) are assigned some number less than 1, while polygons with maximum accessibility (e.g., extractive reserves) are assigned a value 1. These polygons can be land management units or a regular array or hexagons or grid squares.
 

--- a/source/es/coastal_blue_carbon.rst
+++ b/source/es/coastal_blue_carbon.rst
@@ -64,14 +64,14 @@ Figura 1. Tres reservorios de carbono para los ecosistemas marinos incluidos en 
 
 .. note::
         Aunque este capítulo de la guía de uso se refiere a unidades en Megatoneladas de
-        CO2 equivalente por hectárea, el modelo no realiza ninguna conversión de unidades, 
-        por lo que se puede usar cualquier unidad que represente la tasa de acumulación o las emisiones 
+        CO2 equivalente por hectárea, el modelo no realiza ninguna conversión de unidades,
+        por lo que se puede usar cualquier unidad que represente la tasa de acumulación o las emisiones
         específicas del hábitat, con tal de que sean coherentes en todos los inputs del modelo.
 
 Almacenamiento de carbono
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Los hábitats costeros de carbono azul pueden indicar simplemente el tipo de vegetación dominante (por ejemplo, pasto marino, manglar, etc.) o pueden basarse en detalles que afectan a los valores de almacenamiento de la reserva, como las especies vegetales, la densidad de la temperatura o la edad de la vegetación (por ejemplo, el tiempo transcurrido desde la restauración o la última gran perturbación). 
+Los hábitats costeros de carbono azul pueden indicar simplemente el tipo de vegetación dominante (por ejemplo, pasto marino, manglar, etc.) o pueden basarse en detalles que afectan a los valores de almacenamiento de la reserva, como las especies vegetales, la densidad de la temperatura o la edad de la vegetación (por ejemplo, el tiempo transcurrido desde la restauración o la última gran perturbación).
 
 Para la estimación del almacenamiento de carbono, se supone que cada hábitat costero de carbono azul está en equilibrio de almacenamiento en cualquier momento (la acumulación de de carbono se tendrá en cuenta en el componente de secuestración del modelo).
 
@@ -188,8 +188,8 @@ La opción de valoración del modelo de carbono azul estima el valor económico 
    los tipos de descuento reflejan las preferencias temporales de la sociedad. Para una introducción a las
    tasas sociales de descuento, véase Baumol (1968).
  * Dado que los daños ocasionados por las emisiones de carbono se producen más allá de la fecha de
-   de su liberación inicial a la atmósfera, los daños de las emisiones en un periodo determinado 
-   son la suma de los daños futuros, descontados hasta ese momento.   
+   de su liberación inicial a la atmósfera, los daños de las emisiones en un periodo determinado
+   son la suma de los daños futuros, descontados hasta ese momento.
    Por ejemplo, para calcular el CSC de las emisiones en 2030, el valor actual (en
    2030) de la suma de los daños futuros (a partir de 2030) se necesita. Esto significa que
    el CSC en cualquier período futuro es una función de la tasa de descuento, y
@@ -298,7 +298,7 @@ Inputs
 
   Columnas:
 
-  - :investspec:`coastal_blue_carbon.preprocessor lulc_lookup_table_path.columns.code`
+  - :investspec:`coastal_blue_carbon.preprocessor lulc_lookup_table_path.columns.lucode`
   - :investspec:`coastal_blue_carbon.preprocessor lulc_lookup_table_path.columns.lulc-class`
   - :investspec:`coastal_blue_carbon.preprocessor lulc_lookup_table_path.columns.is_coastal_blue_carbon_habitat`
 
@@ -339,7 +339,7 @@ Los archivos resultantes para el preprocesamiento están en la carpeta **Workspa
 
 - **carbon_pool_transient_template_[Suffix].csv**: CSV (.csv, valor separado por comas) tabla de formato, mapea cada tipo de LULC por información de impacto y acumulación.
   Debe llenar todas las columnas de esta tabla excepto las
-  'lulc-class' y 'code', que serán llenadas por el modelo.
+  'lulc-class' y 'lucode', que serán llenadas por el modelo.
   Véase *paso 2. El modelo principal* con más información. Las unidades de acumulación son
   (megatoneladas de CO\ :sub:`2` e/ha-año), la vida media es un entero en años, y
   la perturbación es un entero en porcentaje.
@@ -347,7 +347,7 @@ Los archivos resultantes para el preprocesamiento están en la carpeta **Workspa
  la tabla editada es utilizada como input al modelo principal de carbono azul costero como la **Tabla Biofísica**.
 
   ==========  ==========  ===============  ============  ==============  =================  ==========================  ==========================  ===========================  ===========================  ==============  =======================  =======================  ========================  ========================  ==========================
-  code        lulc-class  biomass-initial  soil-initial  litter-initial  biomass-half-life  biomass-low-impact-disturb  biomass-med-impact-disturb  biomass-high-impact-disturb  biomass-yearly-accumulation  soil-half-life  soil-low-impact-disturb  soil-med-impact-disturb  soil-high-impact-disturb  soil-yearly-accumulation  litter-yearly-accumulation
+  lucode      lulc-class  biomass-initial  soil-initial  litter-initial  biomass-half-life  biomass-low-impact-disturb  biomass-med-impact-disturb  biomass-high-impact-disturb  biomass-yearly-accumulation  soil-half-life  soil-low-impact-disturb  soil-med-impact-disturb  soil-high-impact-disturb  soil-yearly-accumulation  litter-yearly-accumulation
   ==========  ==========  ===============  ============  ==============  =================  ==========================  ==========================  ===========================  ===========================  ==============  =======================  =======================  ========================  ========================  ==========================
   <int>       <lulc1>
   <int>       <lulc2>
@@ -380,7 +380,7 @@ Inputs
 
   Columnas:
 
-  - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.code`
+  - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.lucode`
   - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.lulc-class`
   - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.biomass-initial`
   - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.soil-initial`
@@ -418,13 +418,13 @@ Inputs
 
  El valor de la secuestración de carbono a lo largo del tiempo está dado por:
 
- * **Valor de la tonelada de carbono secuestrado**: esta guía asume que el carbono es 
-   medido en toneladas de CO\ :sub:`2`. Si tiene precios en términos de toneladas de 
+ * **Valor de la tonelada de carbono secuestrado**: esta guía asume que el carbono es
+   medido en toneladas de CO\ :sub:`2`. Si tiene precios en términos de toneladas de
    carbono elemental, estos deben ser convertidos a precios por tonelada de CO\
-   :sub:`2`. Esto requiere la división del precio por un factor de 3,67 para reflejar 
+   :sub:`2`. Esto requiere la división del precio por un factor de 3,67 para reflejar
    la diferencia en la masa atómica entre CO\ :sub:`2` y carbono elemental.
    Otra vez, este valor puede ingresarse usando un horario de precios a lo largo del
-   horizonte temporal adecuado, o proveyendo un año base de precio del carbono y una tasa anual de 
+   horizonte temporal adecuado, o proveyendo un año base de precio del carbono y una tasa anual de
    inflación. Se puede usar cualquier moneda, pero debe haber consistencia al respecto en los inputs de valoración.
 
  * **Tasa de descuento**: (:math:`d` en la ecuación de valor presente neto), que
@@ -458,7 +458,7 @@ Resultados
 
 **Espacio de trabajo/resultados**
 
-- **carbon-accumulation-between-[year]-and-[year][Suffix].tif**. Cantidad de 
+- **carbon-accumulation-between-[year]-and-[year][Suffix].tif**. Cantidad de
   carbono acumulado entre los dos años especificados. Unidades: Megatoneladas CO\
   :sub:`2` e por hectárea
 
@@ -466,7 +466,7 @@ Resultados
   perdido por la perturbación entre los dos años especificados. Unidades: Megatoneladas CO\
   :sub:`2` e por hectárea
 
-- **carbon-stock-at-[year][Suffix].tif**. Suma de las 3 reservas de carbono para cada 
+- **carbon-stock-at-[year][Suffix].tif**. Suma de las 3 reservas de carbono para cada
   LULC para el años especificado. Unidades: Megatoneladas CO\ :sub:`2` e por hectárea
 
 - **total-net-carbon-sequestion-between-[year]-and-[year][Suffix].tif**. Secuestración

--- a/source/es/habitat_quality.rst
+++ b/source/es/habitat_quality.rst
@@ -67,11 +67,11 @@ El impacto de las amenazas sobre el hábitat en una celda de la cuadrícula est�
 
 .. math:: i_{rxy}=1-\left( \frac{d_{xy}}{d_{r\ \mathrm{max}}}\right)\ \mathrm{if\ linear}
 	:label: (hq. 1)
-	
+
 .. math:: i_{rxy}=exp\left(-\left(\frac{2.99}{d_{r\ \mathrm{max}}}\right)d_{xy}\right)\mathrm{if\ exponential}
 	:label: (hq. 2)
 
-	
+
 donde :math:`d_{xy}` es la distancia lineal entre las celdas de la cuadrícula :math:`x` y :math:`y` y :math:`d_{r}` es la distancia efectiva máxima del alcance de la amenaza :math:`r` en el espacio. La Figura 1 ilustra la relación entre la tasa de decaimiento de la distancia de una amenaza en función de la distancia efectiva máxima de la misma (lineal y exponencial). Por ejemplo, si se selecciona una disminución exponencial y la distancia máxima de impacto de una amenaza se establece en 1 km, el impacto de la amenaza en el hábitat de una celda de la cuadrícula disminuirá en un ~ 50% cuando la celda de la cuadrícula esté a 200 m del origen de :math:`r`. Si :math:`i_{rxy} > 0` entonces la celda de la cuadrícula :math:`x` está en la zona de perturbación de la fuente de degradación :math:`ry` (si se utiliza la función exponencial para describir el impacto de la fuente de degradación :math:`r` en el paisaje, entonces el modelo ignora los valores de :math:`i_{rxy}` que están muy cerca de 0 para agilizar el proceso de modelización). Para reiterar, si hemos asignado calificaciones de idoneidad de hábitat específicas para cada grupo de especies a cada LULC, entonces el impacto de la amenaza en el espacio debería ser específico para el grupo de especies modelizado.
 
 |
@@ -114,7 +114,7 @@ y :math:`z` (codificamos :math:`z = 2.5`) y :math:`k` son parámetros de escala 
    :header-rows: 1
    :widths: auto
 
-Tabla 1. Posibles fuentes de degradación basadas en las causas de peligro para las especies en EE.UU. clasificadas como amenazadas o en peligro por el Servicio de Pesca y Vida Silvestre de EE.UU. Adaptado de Czech et al. (2000). 
+Tabla 1. Posibles fuentes de degradación basadas en las causas de peligro para las especies en EE.UU. clasificadas como amenazadas o en peligro por el Servicio de Pesca y Vida Silvestre de EE.UU. Adaptado de Czech et al. (2000).
 
 |
 
@@ -164,7 +164,7 @@ Necesidades de datos
 - :investspec:`habitat_quality threats_table_path`
 
 .. note:: Las localizaciones del sistema de ficheros para *cur_path*, *base_path* y *fut_path* son relativas a la localización de la **Tabla de Amenazas**. Por ejemplo, si *cur_path* es "amenaza1.tif", significa que "amenaza.tif" se encuentra en la misma carpeta que la **Tabla de Amenazas**. Si *cur_path* es "carpeta_amenazas/amenaza1.tif", significa que hay una carpeta "carpeta_amenazas" en la misma ubicación que la **Tabla de Amenazas**, y que "amenaza1.tif" se encuentra dentro de "carpeta_amenazas". También puede proporcionar rutas absolutas, como "C:/HabitatQuality/carpeta_amenazas/amenaza1.tif".
-  
+
   Columnas:
 
   - :investspec:`habitat_quality threats_table_path.columns.threat`
@@ -176,55 +176,56 @@ Necesidades de datos
   - :investspec:`habitat_quality threats_table_path.columns.fut_path`
 
   **Estudio de ejemplo**
-  
+
   Estudio hipotético con tres amenazas para los escenarios actuales y futuros. La agricultura (*Agric* en la tabla) degrada el hábitat a mayor distancia que las carreteras y tiene una mayor magnitud de impacto global. Además, las carreteras pavimentadas (*Paved_rd*) atraen más tráfico que los caminos de tierra (*Dirt_rd*) y, por tanto, son más destructivas para el hábitat cercano que los caminos de tierra. Las rutas de archivos son relativas a la tabla de datos de amenazas, por lo que en este caso las amenazas actuales se encuentran en el mismo directorio que la tabla y las amenazas futuras se encuentran en un subdirectorio adyacente a la tabla de datos de amenazas llamado *future*. Las rutas de los archivos de las amenazas de la línea de base se dejan en blanco porque no tenemos rasters de amenazas para ese escenario O no hemos incluido la línea de base LULC en nuestra ejecución del modelo.
 
-  ========   ========  ===========  =========== ============ =================  =======================
-  AMENAZA    DIST_MAX  PONDERACION  DeCAIMIENTO RUTA_BASE    RUTA_ACTUAL        RUTA_FUTURA
-  ========   ========  ===========  =========== ============ =================  =======================
-  Dirt_rd    2         0.1          linear                   dirt_rd.tif        future/dirt_rd_fut.tif
-  Paved_rd   4         0.4          exponential              paved_rd.tif       future/paved_rd_fut.tif
-  Agric      8         1            linear                   agric_rd.tif       future/agric_rd_fut.tif
-  ========   ========  ===========  =========== ============ =================  =======================
+  ========   ========  ======  =========== ============ =================  =======================
+  threat     max_dist  weight  decay       base_path    cur_path           fut_path
+  ========   ========  ======  =========== ============ =================  =======================
+  Dirt_rd    2         0.1     linear                   dirt_rd.tif        future/dirt_rd_fut.tif
+  Paved_rd   4         0.4     exponential              paved_rd.tif       future/paved_rd_fut.tif
+  Agric      8         1       linear                   agric_rd.tif       future/agric_rd_fut.tif
+  ========   ========  ======  =========== ============ =================  =======================
 
 **Información de los rásters de amenazas**
-  
+
   Archivos ráster SIG de la distribución e intensidad de cada amenaza individual, con valores entre 0 y 1. Tendrá tantos de estos mapas como amenazas tenga y la ruta de los archivos ráster debe definirse en la tabla **Datos de amenazas**. La extensión y resolución de estos conjuntos de datos ráster no tiene por qué ser idéntica a la de los mapas LULC de input. En los casos en que las resoluciones de los mapas de amenazas y LULC varíen, el modelo utilizará la resolución y la extensión del mapa LULC. Cada celda del ráster contiene un valor que indica la densidad o la presencia de una amenaza en su interior (por ejemplo, la superficie agrícola, la longitud de las carreteras, o simplemente un 1 si la celda de la cuadrícula es una carretera o un campo de cultivo y un 0 en caso contrario). Todas las amenazas deben medirse en la misma escala y unidades (es decir, todas se miden en términos de densidad o todas se miden en términos de presencia/ausencia) y no una combinación de métricas. No deje ninguna zona en los mapas de amenazas como "Sin datos". Si los píxeles no contienen esa amenaza, establezca el nivel de amenaza de los píxeles como 0.
-	
+
   InVEST no le pedirá estos rásters en la interfaz de la herramienta, sino que buscará sus rutas de archivo en la tabla de **Datos de amenazas** bajo las columnas de los escenarios correspondientes. Las rutas deben ser **relativas** a la ruta de la tabla de **Amenazas**.
-  
+
   Por último, tenga en cuenta que asumimos que las ponderaciones relativas de las amenazas y la sensibilidad del hábitat a las amenazas no cambian con el tiempo, por lo que solo presentamos una tabla de datos de amenazas y una tabla de datos de sensibilidad del hábitat. Si quiere cambiarlos a lo largo del tiempo, tendrá que ejecutar el modelo varias veces.
-	
+
   En los conjuntos de datos de muestra, los rásters de amenazas se almacenan en el mismo directorio que la tabla de datos de Amenazas y se definen en la tabla de datos de Amenazas bajo el nombre de la columna correspondiente de la siguiente manera: **RUTA_ACTUAL**: crops_c.tif; railroad_c.tif; urban_c.tif; timber_c.tif; roads1_c.tif; roads2_c.tif; roads3_c.tif; **RUTA_FUTURA**: crops_f.tif; railroad_f.tif; urban_f.tif; timber_f.tif; roads1_f.tif; roads2_f.tif; roads3_f.tif. Al introducir los archivos LULC de referencia y de escenario futuro que se encuentran en el conjunto de datos de muestra, estamos ejecutando un análisis de la calidad del hábitat para los mapas de escenario LULC actuales y futuros. No se generará un mapa de calidad del hábitat para el mapa de referencia porque no hemos proporcionado ninguna capa de amenazas para el mapa de referencia y hemos dejado esas columnas en blanco en la tabla de datos de amenazas. La denominación "cultivos" se refiere a las tierras de cultivo, "ferrocarril" a las vías férreas, "urbano" a lo urbano, "madera" a la silvicultura de rotación, "carreteras1" a las carreteras primarias, "carreteras2" a las secundarias y "carreteras3" a las terciarias.
 
 - :investspec:`habitat_quality sensitivity_table_path`
 
   Columnas:
 
-  - :investspec:`habitat_quality sensitivity_table_path.columns.lulc`
+  - :investspec:`habitat_quality sensitivity_table_path.columns.lucode`
+  - :investspec:`habitat_quality sensitivity_table_path.columns.name`
   - :investspec:`habitat_quality sensitivity_table_path.columns.habitat` Esto es :math:`H_j` en las ecuaciones anteriores. Si desea simplemente clasificar cada LULC como hábitat o no sin referencia a ningún grupo de especies en particular, utilice 0 y 1 donde un 1 indica hábitat. De lo contrario, si se dispone de suficiente información sobre las preferencias de hábitat de un grupo de especies, asigne al LULC una calificación relativa de idoneidad de hábitat entre 0 y 1, donde 1 indica la mayor idoneidad de hábitat. Por ejemplo, un pájaro cantor de pradera puede preferir un hábitat de pradera nativa por encima de todos los demás tipos de hábitat (a la pradera se le asigna una calificación de "HABITAT" de 1 para las aves de pradera), pero también utilizará un campo de heno gestionado o un pasto si la pradera no está disponible (al campo de heno manejado y al pasto se les asigna una calificación de "HABITAT" de 0,5 para las aves de pradera).
 
   - :investspec:`habitat_quality sensitivity_table_path.columns.[THREAT]` Aunque el LULC no se considere hábitat, no deje su sensibilidad a cada amenaza como Nula o en blanco, en su lugar introduzca un 0.
 
   *Ejemplo:* Un estudio hipotético con cuatro tipos de LULC y tres amenazas. En este ejemplo tratamos el bosque cerrado y el mosaico forestal como hábitat (absoluto) y el suelo desnudo y el cultivo como no-hábitat (absoluto). El mosaico forestal es el tipo de hábitat más sensible (menos resistente), y es más sensible a los caminos de tierra (DIRT_RD, valor 0,9) que a los caminos pavimentados (PAVED_RD, valor 0,5) o a la agricultura (AGRIC valor 0,8). Introducimos 0s en todas las amenazas para las dos cubiertas de tierra desarrolladas, Suelo desnudo y Cultivo, ya que no son hábitat.
 
-  ====    ================ ======= ======= ==========  =========
-  LULC    NOMBRE           HABITAT AGRIC   PAVED_RD    DIRT_RD
-  ====    ================ ======= ======= ==========  =========
-  1       Suelo denudo     0       0       0           0
-  2       Bosque cerrado   1       0.5     0.2         0.4
-  3       Cultivo          0       0       0           0
-  4       Mosaico forestal 1       0.8     0.8         0.5
-  ====    ================ ======= ======= ==========  =========
+  ======    ================ ======= ======= ==========  =========
+  lucode    name             habitat agric   paved_rd    dirt_rd
+  ======    ================ ======= ======= ==========  =========
+  1         Suelo denudo     0       0       0           0
+  2         Bosque cerrado   1       0.5     0.2         0.4
+  3         Cultivo          0       0       0           0
+  4         Mosaico forestal 1       0.8     0.8         0.5
+  ======    ================ ======= ======= ==========  =========
 
 - :investspec:`habitat_quality access_vector_path` A los polígonos con accesibilidad mínima (por ejemplo, reservas naturales estrictas, tierras privadas bien protegidas) se les asigna algún número inferior a 1, mientras que a los polígonos con accesibilidad máxima (por ejemplo, reservas extractivas) se les asigna el valor 1. Estos polígonos pueden ser unidades de manejo de la tierra o un conjunto regular de hexágonos o cuadrículas.
-  
+
   Campo:
 
   - :investspec:`habitat_quality access_vector_path.fields.access`
 
 
-- :investspec:`habitat_quality half_saturation_constant` Es :math:`k` en la ecuación :eq:`(hq. 4)`. El valor por defecto es 0,05. En general, se desea establecer :math:`k` a la mitad del valor más alto de degradación de la celda de la cuadrícula en el paisaje. Para realizar esta calibración del modelo tendrá que ejecutar el modelo una vez para encontrar el valor de degradación más alto y establecer :math:`k` para su paisaje. Por ejemplo, si una ejecución preliminar del modelo genera un mapa de degradación en el que el nivel más alto de degradación de las celdas de la cuadrícula es 1, entonces establecer :math:`k` en 0,5 producirá mapas de calidad del hábitat con la mayor variación en la escala de 0 a 1 (esto ayuda a la representación visual de la heterogeneidad en la calidad a través del paisaje). Es importante señalar que el orden de clasificación de las celdas de la cuadrícula en la métrica de calidad del hábitat es invariable a su elección de :math:`k`. La elección de :math:`k` solo determina la dispersión y la tendencia central de las calificaciones de calidad del hábitat. Es importante utilizar el mismo valor de :math:`k` para todas las ejecuciones que incluyan el mismo paisaje. Si quiere cambiar su elección de :math:`k` para cualquier ejecución del modelo, entonces deberá cambiar los parámetros para todas las ejecuciones del modelo. 
+- :investspec:`habitat_quality half_saturation_constant` Es :math:`k` en la ecuación :eq:`(hq. 4)`. El valor por defecto es 0,05. En general, se desea establecer :math:`k` a la mitad del valor más alto de degradación de la celda de la cuadrícula en el paisaje. Para realizar esta calibración del modelo tendrá que ejecutar el modelo una vez para encontrar el valor de degradación más alto y establecer :math:`k` para su paisaje. Por ejemplo, si una ejecución preliminar del modelo genera un mapa de degradación en el que el nivel más alto de degradación de las celdas de la cuadrícula es 1, entonces establecer :math:`k` en 0,5 producirá mapas de calidad del hábitat con la mayor variación en la escala de 0 a 1 (esto ayuda a la representación visual de la heterogeneidad en la calidad a través del paisaje). Es importante señalar que el orden de clasificación de las celdas de la cuadrícula en la métrica de calidad del hábitat es invariable a su elección de :math:`k`. La elección de :math:`k` solo determina la dispersión y la tendencia central de las calificaciones de calidad del hábitat. Es importante utilizar el mismo valor de :math:`k` para todas las ejecuciones que incluyan el mismo paisaje. Si quiere cambiar su elección de :math:`k` para cualquier ejecución del modelo, entonces deberá cambiar los parámetros para todas las ejecuciones del modelo.
 
 .. _hq-interpreting-results:
 
@@ -241,15 +242,15 @@ Interpretación de los resultados
 * Carpeta **[Espacio de trabajo]\\resultados**:
 
   * **deg_sum_out_c_[Sufijo].tif** -- Nivel relativo de degradación del hábitat en el paisaje actual. Una calificación alta en una celda de la cuadrícula significa que la degradación del hábitat en la celda es alta en relación con otras celdas. Las celdas de la cuadrícula con cobertura de tierra sin hábitat (LULC con :math:`H_j` = 0) obtienen una calificación de degradación de 0. Este es un mapeo de las calificaciones de degradación calculadas con la ecuación (3).
-	
+
   * **deg_sum_out_f_[Sufijo].tif** -- Nivel relativo de degradación del hábitat en el paisaje futuro. Una calificación alta en una celda de la cuadrícula significa que la degradación del hábitat en la celda es alta en relación con otras celdas. Este resultado solo se crea si se da un mapa LULC futuro como input. Las celdas de la cuadrícula con cobertura de tierra sin hábitat (LULC con :math:`H_j` = 0) obtienen una calificación de degradación de 0. Este es un mapeo de las calificaciones de degradación calculadas con la ecuación (3).
 
   * **quality_out_c_[Sufijo].tif** -- Nivel relativo de la calidad del hábitat en el paisaje actual. Los números más altos indican una mejor calidad del hábitat con respecto a la distribución de la calidad del hábitat en el resto del paisaje. Las zonas del paisaje que no son hábitat reciben una calificación de calidad de 0. Esta calificación de calidad no tiene unidad y no se refiere a ninguna medida de biodiversidad en particular. Se trata de un mapeo de las calificaciones de calidad del hábitat calculadas con la ecuación (4).
-	
+
   * **quality_out_f_[Sufijo.tif** -- Nivel relativo de calidad del hábitat en el paisaje futuro. Los números más altos indican una mejor calidad del hábitat con respecto a la distribución de la calidad del hábitat en el resto del paisaje. Este resultado solo se crea si se da un mapa LULC futuro como input. Las zonas del paisaje que no son hábitat reciben una calificación de calidad de 0. Esta calificación de calidad no tiene unidad y no se refiere a ninguna medida de biodiversidad en particular. Se trata de un mapero de las calificaciones de calidad del hábitat calculadas con la ecuación (4).
 
   * **rarity_c_[Sufijo].tif** -- Rareza relativa del hábitat en el paisaje actual con respecto al mapa de referencia. Este resultado solo se crea si se da un mapa LULC de referencia como input. Este mapa proporciona el valor de :math:`R_x` de cada cuadrícula (véase la ecuación (6)).  Los valores de las celdas de la cuadrícula se definen entre un rango de 0 y 1, donde 0,5 indica que no hay cambios en la abundancia entre el mapa de referencia y el actual o el proyectado. Los valores entre 0 y 0,5 indican que un hábitat es más abundante y cuanto más cerca esté el valor de 0, menor será la probabilidad de que la conservación de ese tipo de hábitat en el paisaje actual o futuro sea importante para la conservación de la biodiversidad. Los valores entre 0,5 y 1 indican que un hábitat es menos abundante y cuanto más se acerque el valor a 1, mayor será la probabilidad de que la preservación de ese tipo de hábitat en el paisaje actual o futuro sea importante para la conservación de la biodiversidad. Si el tipo de hábitat LULC no aparece en el paisaje de referencia, el valor de la casilla será 0.
-	
+
   * **rarity_f_[Sufijo].tif** -- Rareza relativa del hábitat en el paisaje futuro con respecto al mapa de referencia. Este resultado solo se crea si se dan como input los mapas de LULC de la línea base y futuros. Este mapa proporciona el valor de :math:`R_x` de cada cuadrícula (véase la ecuación (6)).  Los valores de las celdas de la cuadrícula se definen entre un rango de 0 y 1, donde 0,5 indica que no hay cambios en la abundancia entre el mapa de referencia y el actual o el proyectado. Los valores entre 0 y 0,5 indican que un hábitat es más abundante y cuanto más cerca esté el valor de 0, menor será la probabilidad de que la preservación de ese tipo de hábitat en el paisaje actual o futuro sea importante para la conservación de la biodiversidad. Los valores entre 0,5 y 1 indican que un hábitat es menos abundante y cuanto más se acerque el valor a 1, mayor será la probabilidad de que la preservación de ese tipo de hábitat en el paisaje actual o futuro sea importante para la conservación de la biodiversidad. Si el tipo de hábitat LULC no aparece en el paisaje de referencia, el valor de la casilla será 0.
 
 * carpeta **[Espacio_de_trabajo]\\intermedio** :

--- a/source/zh/coastal_blue_carbon.rst
+++ b/source/zh/coastal_blue_carbon.rst
@@ -18,7 +18,7 @@ InVEST海岸带蓝碳模型的结果可用于比较碳储量和净封存的当�
 简介
 ============
 
-该模型利用了各种信息，包括: 
+该模型利用了各种信息，包括:
 
 - 海岸植被的分布和丰度
 - 特定栖息地碳储量数据
@@ -93,7 +93,7 @@ InVEST 海岸带蓝碳通过记账类型的方法对碳循环进行建模(Hought
 
 请注意，排放`E_{p,t}`被计算为一个正数值，并且`-1`需要反映碳库中碳的损失。
 
-请注意，以上仅适用于生物量和土壤。凋落物存量不受排放的影响，因此只能按照用户在生物物理表中定义的速率线性累积: 
+请注意，以上仅适用于生物量和土壤。凋落物存量不受排放的影响，因此只能按照用户在生物物理表中定义的速率线性累积:
 
 .. math::
         S_{p_{litter},t} = S_{p_{litter},t_{baseline}} + (A_{p_{litter}} \cdot (t - t_{baseline}))
@@ -212,7 +212,7 @@ SCC的替代方案是碳信用市场价值法。如果决策者是个人或公�
 
 土地利用/土地覆盖(LULC)地图提供了用地变化的快照图，是驱动模型中碳积累和排放的输入。用户必须首先通过土地变化模型(例如SLAMM)、情景评估工具或人工地理信息系统处理来制作一套海岸和海洋栖息地地图。然后，用户必须将LULC映射输入到具有相关年份的模型中，这样就可以确定适当的源和目标转换。
 
-预处理器工具比较映射中的LULC类，以识别发生的所有LULC转换的集合。然后，该工具生成一个转移矩阵，表明两种栖息地之间是否发生了过渡(例如盐沼到已开发的旱地)，以及一旦过渡发生，碳是否会积累、受到干扰或保持不变。碳积累或扰动的性质取决于陆地覆盖是否正在向和/或从沿海蓝碳生境过渡: 
+预处理器工具比较映射中的LULC类，以识别发生的所有LULC转换的集合。然后，该工具生成一个转移矩阵，表明两种栖息地之间是否发生了过渡(例如盐沼到已开发的旱地)，以及一旦过渡发生，碳是否会积累、受到干扰或保持不变。碳积累或扰动的性质取决于陆地覆盖是否正在向和/或从沿海蓝碳生境过渡:
 
 - 其他LULC类`\Rightarrow` 海岸蓝碳栖息地(*碳积累* 在后续年份的过渡事件直到下一个边界年)
 
@@ -234,7 +234,7 @@ SCC的替代方案是碳信用市场价值法。如果决策者是个人或公�
 
  * 我们假设所有有意义的储存、积累和排放都发生在生物量和土壤池中。
  * 我们忽视了随着栖息地的增长和老化而增加的种群和积累。
- * 我们假设碳的储存和积累通过过渡之间的时间是线性的， 
+ * 我们假设碳的储存和积累通过过渡之间的时间是线性的，
  * 我们假设在扰动事件发生后，扰动碳随时间以指数衰减率排放。
  * 我们假设一些可能会破坏沿海生态系统的人类活动不会干扰沉积物中的碳。
  * 我们假设土地覆盖的转变是瞬间发生的，完全发生在转变发生的一年的第一个时刻。
@@ -268,7 +268,7 @@ SCC的替代方案是碳信用市场价值法。如果决策者是个人或公�
 
  列:
 
-  - :investspec:`coastal_blue_carbon.preprocessor lulc_lookup_table_path.columns.code`
+  - :investspec:`coastal_blue_carbon.preprocessor lulc_lookup_table_path.columns.lucode`
   - :investspec:`coastal_blue_carbon.preprocessor lulc_lookup_table_path.columns.lulc-class`
   - :investspec:`coastal_blue_carbon.preprocessor lulc_lookup_table_path.columns.is_coastal_blue_carbon_habitat`
 
@@ -278,7 +278,7 @@ SCC的替代方案是碳信用市场价值法。如果决策者是个人或公�
 
 预处理器的输出文件位于文件夹**Workspace/outputs_preprocessor**中。以下文件名中的“Suffix”指的是模型的可选用户定义后缀输入。
 
-- **Parameter log**:每次运行模型时，将在主Workspace文件夹中创建一个文本(.txt)文件。该文件将列出该运行的参数值和输出消息，并将根据服务、日期和时间命名。当与NatCap联系模型运行中的错误时，请包含此参数日志。 
+- **Parameter log**:每次运行模型时，将在主Workspace文件夹中创建一个文本(.txt)文件。该文件将列出该运行的参数值和输出消息，并将根据服务、日期和时间命名。当与NatCap联系模型运行中的错误时，请包含此参数日志。
 
 - **transitions_[Suffix].csv**: CSV (.csv, 逗号分隔的值) 格式表,
   这是一个转换矩阵，表示从一个LULC类到另一个LULC类的转换中是否发生了扰动或累积。如果单元格为空白，则输入的土地利用/土地覆被栅格之间不会发生这种转换。最左边的列(* LULC -class*)表示源LULC类，最上面的行(<lulc1>, <lulc2>...)表示目标LULC类。根据转换类型的不同，单元格将被预先填充为以下类型之一:如果没有发生这种转变，则为空，‘NCC'(表示无碳变化)，‘accum'(表示积累)或’disturb'(表示扰动)。您必须编辑“干扰”单元格，使其具有由于LULC更改而发生的干扰的程度。这可以通过将“干扰”更改为“低影响-干扰”、“中影响-干扰”或“高影响-干扰”来实现。
@@ -294,13 +294,13 @@ SCC的替代方案是碳信用市场价值法。如果决策者是个人或公�
   ==========  ========  ========  ===
 
 
-- **carbon_pool_transient_template_[Suffix].csv**: CSV (.csv, 逗号分隔的值) 格式表, 将每个LULC类型映射到影响和积累信息。除了‘lulc-class'和’code'列外，您必须填写该表的所有列，这些列将由模型预填充。更多信息请参见*步骤2. 主模型*。累积单位为(Megatonnes of CO\:sub: ' 2è/ha-yr)，半衰期以整数年为单位，扰动以整数百分比为单位。
- 
+- **carbon_pool_transient_template_[Suffix].csv**: CSV (.csv, 逗号分隔的值) 格式表, 将每个LULC类型映射到影响和积累信息。除了‘lulc-class'和’lucode'列外，您必须填写该表的所有列，这些列将由模型预填充。更多信息请参见*步骤2. 主模型*。累积单位为(Megatonnes of CO\:sub: ' 2è/ha-yr)，半衰期以整数年为单位，扰动以整数百分比为单位。
+
 
  编辑后的表格被用作输入到主要的海岸蓝碳模型**生物物理表**。
 
   ==========  ==========  ===============  ============  ==============  =================  ==========================  ==========================  ===========================  ===========================  ==============  =======================  =======================  ========================  ========================  ==========================
-  code        lulc-class  biomass-initial  soil-initial  litter-initial  biomass-half-life  biomass-low-impact-disturb  biomass-med-impact-disturb  biomass-high-impact-disturb  biomass-yearly-accumulation  soil-half-life  soil-low-impact-disturb  soil-med-impact-disturb  soil-high-impact-disturb  soil-yearly-accumulation  litter-yearly-accumulation
+  lucode      lulc-class  biomass-initial  soil-initial  litter-initial  biomass-half-life  biomass-low-impact-disturb  biomass-med-impact-disturb  biomass-high-impact-disturb  biomass-yearly-accumulation  soil-half-life  soil-low-impact-disturb  soil-med-impact-disturb  soil-high-impact-disturb  soil-yearly-accumulation  litter-yearly-accumulation
   ==========  ==========  ===============  ============  ==============  =================  ==========================  ==========================  ===========================  ===========================  ==============  =======================  =======================  ========================  ========================  ==========================
   <int>       <lulc1>
   <int>       <lulc2>
@@ -327,7 +327,7 @@ SCC的替代方案是碳信用市场价值法。如果决策者是个人或公�
 
   列:
 
-  - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.code`
+  - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.lucode`
   - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.lulc-class`
   - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.biomass-initial`
   - :investspec:`coastal_blue_carbon.coastal_blue_carbon biophysical_table_path.columns.soil-initial`
@@ -364,7 +364,7 @@ SCC的替代方案是碳信用市场价值法。如果决策者是个人或公�
 - :investspec:`coastal_blue_carbon.coastal_blue_carbon do_economic_analysis`
 
 
-随时间变化的碳固存值为: 
+随时间变化的碳固存值为:
 
  * **封存一吨碳的价值**: 本用户指南假设碳的计量单位为吨CO2。如果你有以吨碳为单位的价格，这些需要转换为每吨CO2。这需要将价格除以3.67，以反映CO2和碳元素之间原子质量的差异。同样，这个值可以使用适当时间范围内的价格表来输入，或者通过提供基准年碳价格和年度通胀率来输入。任何货币都可以使用，只要它在所有估值输入中是一致的。
 
@@ -433,7 +433,7 @@ SCC的替代方案是碳信用市场价值法。如果决策者是个人或公�
 高级用法:空间显式生物物理参数
 ---------------------------------------------------------
 
-虽然海岸带蓝碳的预处理器和主要模型的用户界面对大多数可分为不同地表覆盖类型的情况都有帮助，但高级用户可能希望为模型提供碳半衰期、积累速率和其他生物物理参数的空间显式地图。这不能通过用户界面实现，但是可以通过python函数来实现，该函数提供对模型时间序列分析的低级访问。使用这种高级功能需要大量的数据预处理，并且有更复杂的数据需求。详情请参阅github上的模型源代码:https://github.com/natcap/invest/blob/main/src/natcap/invest/coastal_b lue_carbon/coastal_blue_carbon.py 
+虽然海岸带蓝碳的预处理器和主要模型的用户界面对大多数可分为不同地表覆盖类型的情况都有帮助，但高级用户可能希望为模型提供碳半衰期、积累速率和其他生物物理参数的空间显式地图。这不能通过用户界面实现，但是可以通过python函数来实现，该函数提供对模型时间序列分析的低级访问。使用这种高级功能需要大量的数据预处理，并且有更复杂的数据需求。详情请参阅github上的模型源代码:https://github.com/natcap/invest/blob/main/src/natcap/invest/coastal_b lue_carbon/coastal_blue_carbon.py
 
 
 示例
@@ -480,7 +480,7 @@ SCC的替代方案是碳信用市场价值法。如果决策者是个人或公�
 
 图CS2。从2006年到2100年，两个情景和自由港研究区域的一个子集的碳排放(红色)和封存(蓝色)。
 
-下表总结了主要输入是如何获得的，从哪里获得的，以及如何在模型中使用的: 
+下表总结了主要输入是如何获得的，从哪里获得的，以及如何在模型中使用的:
 
 +--------------------------------------------+--------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Input                                      | Source                                           | 在InVEST蓝碳模型中使用                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
@@ -511,7 +511,7 @@ SCC的替代方案是碳信用市场价值法。如果决策者是个人或公�
 附录:全球碳值数据库
 ==========================================
 
-如果无法获得当地碳储量和积累率资料，用户不妨利用全球碳储量和积累率数据库，该数据库包含在InVEST CBC模型样本数据中，在此处下载:https://bitbucket.org/natcap/invest-sampledata/src/master/CoastalBlueCarbon/inputs/BlueCarbon_GlobalDB.xls。请注意，如果可以获得来自实地研究或其他本地来源的数据，则应使用这些值而不是全局数据库中的值。 
+如果无法获得当地碳储量和积累率资料，用户不妨利用全球碳储量和积累率数据库，该数据库包含在InVEST CBC模型样本数据中，在此处下载:https://bitbucket.org/natcap/invest-sampledata/src/master/CoastalBlueCarbon/inputs/BlueCarbon_GlobalDB.xls。请注意，如果可以获得来自实地研究或其他本地来源的数据，则应使用这些值而不是全局数据库中的值。
 
 这份excel表格包括盐沼、海草和红树林的碳储量和积累率，以及生物量和土壤池中的碳积累率。碳生物量储量以吨CO2当量/公顷为单位提供，碳积累速率以吨CO2当量/公顷/年为单位提供。
 

--- a/source/zh/habitat_quality.rst
+++ b/source/zh/habitat_quality.rst
@@ -66,12 +66,12 @@ InVEST生境质量模型结合了LULC和生物多样性威胁的信息，以生�
 
 .. math:: i_{rxy}=1-\left( \frac{d_{xy}}{d_{r\ \mathrm{max}}}\right)\ \mathrm{if\ linear}
 	:label: (hq. 1)
-	
+
 .. math:: i_{rxy}=exp\left(-\left(\frac{2.99}{d_{r\ \mathrm{max}}}\right)d_{xy}\right)\mathrm{if\ exponential}
 	:label: (hq. 2)
 
 
-	
+
 式中：:math:`d_{xy}` 是栅格:math:`x` 和:math:`y` 之间的线性距离；:math:`d_{r\ \mathrm{max}}` 是威胁:math:`r` 's的最大作用距离。图1表明基于威胁的最大衰减距离(线性和指数)，距离与衰减率之间的相关关系。例如，如果用户选择指数降低和威胁最大影响距离设置为1km，当栅格离威胁源有200m时，威胁对栅格生境的影响将下降50%。如果:math:`i_{rxy}>0`，那么栅格:math:`x`在退化的威胁:math:`ry` 的干扰区域内。反复做，如果我们给每种LULC分配物种群落和生境适宜性得分，那么威胁的空间特征将会对模拟的物种种群有特定的影响。
 
 |
@@ -163,7 +163,7 @@ InVEST生境质量模型结合了LULC和生物多样性威胁的信息，以生�
 - :investspec:`habitat_quality threats_table_path`
 
 .. note:: *cur_path*、*base_path* 和 *fut_path* 的文件系统位置相对于“威胁表”的位置。例如，如果 *cur_path* 为“threat1.tif”，则表示“threat.tif”与“威胁表”位于同一文件夹中。如果 *cur_path* 为“threat_folder/threat1.tif”，则表示与“威胁表”位于同一位置的文件夹“threat_folder”，并且“threat1.tif”位于“threat_folder”内。您还可以提供绝对路径，例如“C：/HabitatQuality/threat_folder/threat1.tif”。
-  
+
  目录:
 
   - :investspec:`habitat_quality threats_table_path.columns.threat`
@@ -175,11 +175,11 @@ InVEST生境质量模型结合了LULC和生物多样性威胁的信息，以生�
   - :investspec:`habitat_quality threats_table_path.columns.fut_path`
 
   **案例研究**
-  
+
 对当前和未来情景的三种威胁的假设研究。农业(表中*Agric*)退化生境的距离比道路更远，总体影响也更大。此外，铺好的路(*Paved_rd*)比土路(*Dirt_rd*)吸引更多的交通，因此比土路对附近生境的破坏更大。文件路径是相对于Threat数据表的，因此在本例中，当前威胁位于与该表相同的目录中，而未来威胁位于与威胁数据表相邻的子目录*future*中。基线威胁文件路径是空白的，因为我们没有该场景的威胁栅格，或者我们没有将基线LULC包含在我们运行的模型中。
 
   ========   ========  ======  =========== ============ =================  =======================
-  THREAT     MAX_DIST  WEIGHT  DECAY        BASE_PATH     CUR_PATH         FUT_PATH
+  threat     max_dist  weight  decay       base_path    cur_path           fut_path
   ========   ========  ======  =========== ============ =================  =======================
   Dirt_rd    2         0.1     linear                   dirt_rd.tif        future/dirt_rd_fut.tif
   Paved_rd   4         0.4     exponential              paved_rd.tif       future/paved_rd_fut.tif
@@ -187,13 +187,13 @@ InVEST生境质量模型结合了LULC和生物多样性威胁的信息，以生�
   ========   ========  ======  =========== ============ =================  =======================
 
   **威胁栅格信息**
-  
+
 每个威胁的分布和强度的GIS栅格文件，值在0到1之间。您将拥有与威胁相同数量的这些映射，栅格文件路径应该在**威胁数据**表中定义。这些栅格数据集的范围和分辨率不需要与输入的LULC地图相同。在威胁和LULC分辨率不同的情况下，模型将使用LULC的分辨率和范围。栅格中的每个单元格都包含一个值，表示其内部威胁的密度或存在程度(例如，农业面积、道路长度，如果网格单元格是道路或农田，则简单地为1，否则为0)。所有威胁都应该用相同的尺度和单位来衡量(例如，所有威胁都用密度来衡量，或者所有威胁都用存在/缺失来衡量)，而不是用某种指标的组合来衡量。不要让威胁地图上的任何区域显示为“无数据”。如果栅格不包含该威胁，则将栅格的威胁级别设置为0。
-	
+
 InVEST不会在工具界面中提示您这些栅格，而是在相应场景列下的**Threats data**表中查找它们的文件路径。路径应该相对于**Threats data**表路径。
-  
+
 最后，请注意，我们假设威胁的相对权重和栖息地对威胁的敏感性不会随时间而变化，因此我们只提交一个威胁数据表和一个栖息地敏感度数据表。如果要随时间推移更改这些内容，则必须多次运行模型。
-	
+
 在示例数据集中，威胁栅格存储在与威胁数据表相同的目录中，并在威胁数据表中按相应列名进行定义，如下所示：**CUR_PATH**:
 crops_c.tif; railroad_c.tif; urban_c.tif; timber_c.tif; roads1_c.tif; roads2_c.tif; roads3_c.tif; **FUT_PATH**: crops_f.tif; railroad_f.tif; urban_f.tif; timber_f.tif; roads1_f.tif; roads2_f.tif; roads3_f.tif. 在输入样例数据集中发现的基线和未来情景LULC文件时，我们正在对当前和未来的LULC情景地图进行生境质量分析。不会为基线地图生成生境质量地图，因为我们没有为基线地图提供任何威胁层，并将威胁数据表中的这些列留空。“农作物”指的是农田，“铁路”指的是火车轨道，“城市”指的是城市，“木材”指的是轮作林业，“1号路”指的是主要道路，“2号路”指的是次要道路，“3号路”指的是轻型道路。
 
@@ -201,24 +201,25 @@ crops_c.tif; railroad_c.tif; urban_c.tif; timber_c.tif; roads1_c.tif; roads2_c.t
 
  列:
 
-  - :investspec:`habitat_quality sensitivity_table_path.columns.lulc`
+  - :investspec:`habitat_quality sensitivity_table_path.columns.lucode`
+  - :investspec:`habitat_quality sensitivity_table_path.columns.name`
   - :investspec:`habitat_quality sensitivity_table_path.columns.habitat` 这是:math:`H_j` 在上面的方程。如果您想简单地将每个LULC分类为生境或不参考任何特定的物种组，则使用0和1，其中1表示生境。或者，如果一个物种群体的生境偏好有足够的信息，为LULC分配一个相对生境适宜性得分，介于0到1之间，其中1表示最高的生境适宜性。例如，一只草原鸟类可能更喜欢原生草原生境(草原鸟类的“生境”得分为1)，但如果没有草原，它也会使用管理的干草田或牧场(草原鸟类的“生境”得分为0.5)。
 
   - :investspec:`habitat_quality sensitivity_table_path.columns.[THREAT]` 即使LULC不被认为是生境，也不要将其对每种威胁的敏感性设置为Null或空白，而是输入0。
 
   *例如:* 有四种LULC类型和三种威胁的假设研究。在该案例中，我们将林地和森林视为(绝对)生境，将裸地和耕地视为(绝对)非生境。森林是最敏感的生境类型，并且对土路(DIRT_RD， 0.9)比铺砌道路(PAVED_RD，0.5)或农业(AGRIC，0.8)更敏感。我们对裸地和耕地这两种已开发土地覆盖的所有威胁都进入0，因为它们不是生境。
 
-  ====    =============== ======= ======= ==========  =========
-  LULC    NAME            HABITAT AGRIC   PAVED_RD    DIRT_RD
-  ====    =============== ======= ======= ==========  =========
-  1       Bare Soil       0       0       0           0
-  2       Closed Woodland 1       0.5     0.2         0.4
-  3       Cultivation     0       0       0           0
-  4       Forest Mosaic   1       0.8     0.8         0.5
-  ====    =============== ======= ======= ==========  =========
+  ======    =============== ======= ======= ==========  =========
+  lucode    name            habitat agric   paved_rd    dirt_rd
+  ======    =============== ======= ======= ==========  =========
+  1         Bare Soil       0       0       0           0
+  2         Closed Woodland 1       0.5     0.2         0.4
+  3         Cultivation     0       0       0           0
+  4         Forest Mosaic   1       0.8     0.8         0.5
+  ======    =============== ======= ======= ==========  =========
 
 - :investspec:`habitat_quality access_vector_path` 具有最小可达性的边界(例如严格的自然保护区，保护良好的私人土地)被分配一个小于1的数字，而具有最大可达性的边界(例如采掘保护区)被分配一个值1。这些边界可以是土地管理单元或规则图形、六边形或方格。
-  
+
   Field:
 
   - :investspec:`habitat_quality access_vector_path.fields.access`
@@ -241,15 +242,15 @@ crops_c.tif; railroad_c.tif; urban_c.tif; timber_c.tif; roads1_c.tif; roads2_c.t
 * **[Workspace]\\output** 文件夹:
 
   * **deg_sum_out_c_[Suffix].tif** -- 当前景观类型的相对生境退化水平。1代表退化度高，0代表退化度低。非生境的栅格(LULC with :math:`H_j` = 0)退化得分值为0。基于公式(3)计算得到退化得分值地图。
-	
+
   * **deg_sum_out_f_[Suffix].tif** -- 未来景观类型的相对生境退化水平。1代表退化度高，0代表退化度低。非生境的栅格(LULC with :math:`H_j` = 0)退化得分值为0。基于公式(3)计算得到退化得分值地图。
 
   * **quality_out_c_[Suffix].tif** -- 当前景观类型的生境质量。较高数值表示较好的生境质量。非生境的景观区域生境得分值为0。质量得分值无量纲，不能反映特定的生物多样性测量。基于公式(4) 计算得到生境质量得分值地图。
-	
+
   * **quality_out_f_[Suffix].tif** -- 未来景观类型的生境质量。较高数值表示较好的生境质量。非生境的景观区域生境得分值为0。质量得分值无量纲，不能反映特定的生物多样性测量。基于公式(4) 计算得到生境质量得分值地图。
 
   * **rarity_c_[Suffix].tif** --当前景观上的相对生境稀缺性。只有在给出基线LULC作为输入时，才会创建此输出。该输出给出了每个栅格的值:math:`R_x` (见式(6))。栅格的值定义在0到1的范围内，其中0.5表示基线和当前地图之间没有变化。数值在0到0.5之间表示生境更丰富，数值越接近0，当前或未来景观上该生境类型的保护对生物多样性保护的重要性可能性越小。数值在0.5到1之间表示生境数量较少，数值越接近1，当前或未来景观上的生境类型的保护对生物多样性保护的重要性就越大。如果基线景观上没有出现LULC生境类型，则栅格值为0。
-	
+
   * **rarity_f_[Suffix].tif** -- 未来景观上的相对生境稀缺性。只有在给出基线LULC作为输入时，才会创建此输出。该输出给出了每个栅格的值:math:`R_x` (见式(6))。栅格的值定义在0到1的范围内，其中0.5表示基线和当前地图之间没有变化。数值在0到0.5之间表示生境更丰富，数值越接近0，当前或未来景观上该生境类型的保护对生物多样性保护的重要性可能性越小。数值在0.5到1之间表示生境数量较少，数值越接近1，当前或未来景观上的生境类型的保护对生物多样性保护的重要性就越大。如果基线景观上没有出现LULC生境类型，则栅格值为0。
 
 * **[Workspace]\\intermediate** folder:
@@ -261,7 +262,7 @@ crops_c.tif; railroad_c.tif; urban_c.tif; timber_c.tif; roads1_c.tif; roads2_c.t
 
 模型输出不提供景观级别的质量和稀有度分数，用于比较基线、当前和未来的LULC情景。相反，用户必须总结每个景观的生境范围、质量和稀有度得分。在最简单的层面上，LULC情景的生境质量景观评分只是该情景下所有网格单元级评分的总和。换句话说，我们可以将来自*quality_out_c.tif*、*quality_out_b.tif* (如果可用)和*quality_out_f.tif* (如果可用)的所有质量分数栅格相加，然后比较分数。地图可能有更高的总体质量分数，原因有几个。首先，它可能有更多的生境面积。然而，如果任何两种情况下的生境数量大致相同，那么景观质量得分越高，表明生境的整体质量越好。
 
-景观中某些区域的分数也可以进行比较。例如，我们可以比较已知在感兴趣物种的地理范围内的景观区域的总体生境质量分数。例如，假设我们有9个物种的地理范围图，并向生境质量模型提供了当前和未来的LULC场景图。在这种情况下，我们将确定18个生境质量总分，在每个场景(当前和未来)下为每个模型物种一次。:math:`G_{s_{\mathrm{cur}}}`表示当前视图中位于:math:`s`'范围内的栅格单元集。然后，以物种为单位的生境质量平均分数:math:`s`'在当前景观上的范围为: 
+景观中某些区域的分数也可以进行比较。例如，我们可以比较已知在感兴趣物种的地理范围内的景观区域的总体生境质量分数。例如，假设我们有9个物种的地理范围图，并向生境质量模型提供了当前和未来的LULC场景图。在这种情况下，我们将确定18个生境质量总分，在每个场景(当前和未来)下为每个模型物种一次。:math:`G_{s_{\mathrm{cur}}}`表示当前视图中位于:math:`s`'范围内的栅格单元集。然后，以物种为单位的生境质量平均分数:math:`s`'在当前景观上的范围为:
 
 .. math:: Q_{s_{\mathrm{cur}}}=\frac{\sum^{G^{s_{\mathrm{cur}}}}_{x=1}Q_{xj_{\mathrm{cur}}}}{G^{s_{\mathrm{cur}}}}
   :label: (hq. 9)


### PR DESCRIPTION
Updates Coastal Blue Carbon & Habitat Quality sections to reflect the columns that have been renamed `lucode` in [InVEST PR #1729](https://github.com/natcap/invest/pull/1729).