### PR TITLE
Add callouts highlighting change to per-hectare units

### DIFF
--- a/source/en/carbon_edge.rst
+++ b/source/en/carbon_edge.rst
@@ -200,6 +200,8 @@ Note that all spatial inputs must be in the same projected coordinate system and
 Interpreting Results
 --------------------
 
+.. note:: As of InVEST 3.15.0, the raster results of the Forest Carbon Edge Effect model are given as values *per hectare*.
+
 Final Results
 ~~~~~~~~~~~~~
 -  **Parameter log**. Each time the model is run, a text (.txt) file will appear in the *Workspace*. The file will list the parameter values for that run and will be named according to the service, date, and time. Please include the parameter log when contacting NatCap about errors in a model run.

--- a/source/en/carbonstorage.rst
+++ b/source/en/carbonstorage.rst
@@ -148,6 +148,8 @@ Data Needs
 Interpreting Results
 ====================
 
+.. note:: As of InVEST 3.15.0, the raster results of the Carbon model are given as values *per hectare*.
+
 * **[Workspace]** folder:
 
 	* **Parameter log**: Each time the model is run, a text (.txt) file will be created in the Workspace. The file will list the parameter values and output messages for that run and will be named according to the service, the date and time. When contacting NatCap about errors in a model run, please include the parameter log.

--- a/source/en/crop_production.rst
+++ b/source/en/crop_production.rst
@@ -179,6 +179,8 @@ Additional Regression Data Needs
 Interpreting Results
 ====================
 
+.. note:: As of InVEST 3.15.0, the raster results of the Crop Production models (both Percentile and Regression) are given as values *per hectare*.
+
 The following is a short description of each of the outputs from the Crop Production model. Final results are found within the user defined Workspace specified for this model run. "Suffix" in the following file names refers to the optional user-defined Suffix input to the model.
 
 - **aggregate_results_[Suffix].csv**: If an Aggregate Results Polygon shapefile is provided, a table is produced that summarizes total observed/percentile/modeled production and nutrient information within each polygon.

--- a/source/en/ndr.rst
+++ b/source/en/ndr.rst
@@ -301,7 +301,7 @@ The model has options to calculate nitrogen, phosphorus, or both. You must provi
 
 - :investspec:`ndr.ndr k_param` The default value is 2.
 
-- :investspec:`ndr.ndr runoff_proxy_av` Entering a custom runoff proxy average instead of using the auto-calculated average ensures consistency across model runs. If you are running this model multiple times with different inputs (e.g., with different watersheds or to compare different climate scenarios) but want to maintain a consistent reference for the runoff proxy index, specifying a fixed RP average ensures comparability (given that :math:`RPI_i` changes depending on which pixels/watersheds are included in the :math:`RP` raster). Note that the average runoff proxy should be >0. 
+- :investspec:`ndr.ndr runoff_proxy_av` Entering a custom runoff proxy average instead of using the auto-calculated average ensures consistency across model runs. If you are running this model multiple times with different inputs (e.g., with different watersheds or to compare different climate scenarios) but want to maintain a consistent reference for the runoff proxy index, specifying a fixed RP average ensures comparability (given that :math:`RPI_i` changes depending on which pixels/watersheds are included in the :math:`RP` raster). Note that the average runoff proxy should be >0.
 
 - :investspec:`ndr.ndr subsurface_critical_length_n`
 
@@ -312,6 +312,8 @@ The model has options to calculate nitrogen, phosphorus, or both. You must provi
 
 Interpreting results
 ====================
+
+.. note:: As of InVEST 3.15.0, the raster results of NDR are given as values *per hectare*.
 
 In the file names below, "x" stands for either n (nitrogen) or p (phosphorus), depending on which nutrients were modeled. The resolution of the output rasters will be the same as the resolution of the DEM provided as input.
 

--- a/source/en/sdr.rst
+++ b/source/en/sdr.rst
@@ -465,7 +465,7 @@ Interpreting Results
 
 .. note:: The resolution of the output rasters will be the same as the resolution of the DEM provided as input.
 
-.. note:: The raster results of SDR are given as values *per hectare*. To convert the per hectare values to per pixel values, adjust by the size of your pixels relative to one hectare. For example: If *1 pixel = 900 m2*, then the conversion from metric tons per hectare (t/ha) to metric tons per pixel (t/pixel) would be: *(t/ha x 1/10000 ha/m2 x 900 m2/pixel)* or *(the per hectare value x (900/10000))*. The number will get smaller when the pixel size is smaller than a hectare.
+.. note:: As of InVEST 3.15.0, the raster results of SDR are given as values *per hectare*. To convert the per hectare values to per pixel values, adjust by the size of your pixels relative to one hectare. For example: If *1 pixel = 900 m2*, then the conversion from metric tons per hectare (t/ha) to metric tons per pixel (t/pixel) would be: *(t/ha x 1/10000 ha/m2 x 900 m2/pixel)* or *(the per hectare value x (900/10000))*. The number will get smaller when the pixel size is smaller than a hectare.
 
 
 * **[Workspace]** folder:


### PR DESCRIPTION
Adds a `note` callout, highlighting new per-hectare outputs, to the "Interpreting Results" section of each affected model (Carbon, Crop Production, Forest Carbon, NDR, SDR).

Example:
<img width="708" alt="ug-per-hectare-note-carbon_2025-03-13" src="https://github.com/user-attachments/assets/d770bdc4-dfd0-421e-a3a7-dbfbbcd290b7" />
