### PR TITLE
Update NDR for nutrient load type feature

### DIFF
--- a/source/en/data_sources.rst
+++ b/source/en/data_sources.rst
@@ -359,6 +359,21 @@ In the United States, free soil data is available from the NRCS gSSURGO, SSURGO 
 
 It is sometimes the case (as with SSURGO data in the United States) that soil group maps are missing data in urban areas. If the urban areas are known to be mostly development and impervious surface, you can set the soil group value for these pixels to 4 (D), which indicates the highest level of rainfall runoff. You could also refine these values based on whether the land use/land cover (LULC) map indicates low-, medium- or high-intensity development.
 
+**Estimating soil hydrologic groups from sand and clay data**
+
+The HYSOGs250m documentation, as well as other sources provide mappings between soil texture information and soil group. Here is one simple mapping provided by https://engineering.purdue.edu/mapserve/LTHIA7/lthianew/hsg.htm:
+
+**Group A** is sand, loamy sand or sandy loam types of soils. It has low runoff potential and high infiltration rates even when thoroughly wetted. They consist chiefly of deep, well to excessively drained sands or gravels and have a high rate of water transmission.
+
+**Group B** is silt loam or loam. It has a moderate infiltration rate when thoroughly wetted and consists chiefly or moderately deep to deep, moderately well to well drained soils with moderately fine to moderately coarse textures.
+
+**Group C** soils are sandy clay loam. They have low infiltration rates when thoroughly wetted and consist chiefly of soils with a layer that impedes downward movement of water and soils with moderately fine to fine structure.
+
+**Group D** soils are clay loam, silty clay loam, sandy clay, silty clay or clay. This HSG has the highest runoff potential. They have very low infiltration rates when thoroughly wetted and consist chiefly of clay soils with a high swelling potential, soils with a permanent high water table, soils with a claypan or clay layer at or near the surface and shallow soils over nearly impervious material.
+
+For a more detailed mapping, including depth to impermeable layer and depth to high water table, see the table in page 5 of this document: http://nesoil.com/upload/RIHSGMethod_20150821.pdf.
+
+
 **Estimating soil hydrologic groups from hydraulic conductivity and soil depth**
 
 If desired, soil groups may also be determined from hydraulic conductivity and soil depths. FutureWater’s Soil Hydraulic Properties dataset also contains hydraulic conductivity, as may other soil databases. Table 1 below can be used to convert soil conductivity into soil groups.
@@ -375,6 +390,8 @@ If desired, soil groups may also be determined from hydraulic conductivity and s
 +----------------------------------------------------------------------------------------------------------------------------------------------------+-------------+----------------+----------------+-----------------------------------------------------------------------+
 | Saturated hydraulic conductivity of the least transmissive layer when any water impermeable layer exists at a depth greater than 100 centimeters   | >10 μm/s    | [4;10] μm/s    | [0.4;4] μm/s   | <0.4 μm/s                                                             |
 +----------------------------------------------------------------------------------------------------------------------------------------------------+-------------+----------------+----------------+-----------------------------------------------------------------------+
+
+For more detail about this method, also see this U.S. National Engineering Handbook chapter on Hydrologic Soil Groups: https://directives.nrcs.usda.gov/sites/default/files2/1712930597/11905.pdf.
 
 .. _cn:
 

--- a/source/en/data_sources.rst
+++ b/source/en/data_sources.rst
@@ -359,6 +359,8 @@ In the United States, free soil data is available from the NRCS gSSURGO, SSURGO 
 
 It is sometimes the case (as with SSURGO data in the United States) that soil group maps are missing data in urban areas. If the urban areas are known to be mostly development and impervious surface, you can set the soil group value for these pixels to 4 (D), which indicates the highest level of rainfall runoff. You could also refine these values based on whether the land use/land cover (LULC) map indicates low-, medium- or high-intensity development.
 
+|
+
 **Estimating soil hydrologic groups from sand and clay data**
 
 The HYSOGs250m documentation, as well as other sources provide mappings between soil texture information and soil group. Here is one simple mapping provided by https://engineering.purdue.edu/mapserve/LTHIA7/lthianew/hsg.htm:
@@ -373,6 +375,7 @@ The HYSOGs250m documentation, as well as other sources provide mappings between 
 
 For a more detailed mapping, including depth to impermeable layer and depth to high water table, see the table in page 5 of this document: http://nesoil.com/upload/RIHSGMethod_20150821.pdf.
 
+|
 
 **Estimating soil hydrologic groups from hydraulic conductivity and soil depth**
 

--- a/source/en/getting_started.rst
+++ b/source/en/getting_started.rst
@@ -36,7 +36,7 @@ This high-level tutorial gives you an idea of the main activities involved with 
 	- Time required to create data for one model: High.
 5. **Create future scenarios**
 	- Analyzing scenarios is optional, but commonly done.
-	- Scenarios are often based on altering land use/land cover, habitat, or land management maps to reflect the impacts of a proposed intervention, or climate change.
+	- Scenarios are often based on altering land use/land cover, habitat, or land management practices to reflect the impacts of a proposed intervention, or climate change.
 	- Creating scenarios may be very time-consuming if, for example, a stakeholder process is used, or climate modeling is required.
 	- Time required to create scenarios: Medium to High.
 6. **Run the model**
@@ -60,7 +60,7 @@ This high-level tutorial gives you an idea of the main activities involved with 
 	- Combine InVEST model results with beneficiary data, generally done using GIS software.
 	- Time requirement: Medium.
 10. **Valuation**
-	- Valuation of ecosystem services, whether monetary or non-monetary, is generally complex and context-specific.
+	- Valuation of ecosystem services, whether monetary or non-monetary, is generally complex and context-specific. It is also optional.
 	- Gather economic data related to the service and beneficiary you're analyzing.
 	- Calibrate your model results before using them for valuation.
 	- Time required: Medium to High.
@@ -209,7 +209,7 @@ Before running InVEST, it is necessary to format your data. Although subsequent 
 
 + If using ESRI GRID format rasters, their dataset names cannot be longer than 13 characters and the first character cannot be a number. TIFF and IMG rasters do not have the file name length limitation. When using ESRI GRID as input to the model interface, use the file "hdr.adf".
 
-+ Spatial data must be in a projected coordinate system (such at UTM), not a geographic coordinate system (such as WGS84), and all input data for a given model run must be in the same projected coordinate system. If your data is not projected, InVEST will give errors or incorrect results. (There are exceptions to this, such as Coastal Vulnerability - see the model's User Guide chapter for specific requirements.)
++ For most InVEST models, spatial data must be in a projected coordinate system (such at UTM, with distance units of meters), *not* a geographic coordinate system (such as WGS84, with distance units of degrees), and all input data for a given model run must be in the same projected coordinate system. If your data is not projected, InVEST will give errors or incorrect results. (There are exceptions to this, such as the Coastal Vulnerability model - see the model's User Guide chapter for specific requirements.)
 
 + Every raster that is used as input to InVEST models must have a numeric data value assigned to the raster's *NoData* value. This *NoData* value must not be considered valid model data. For example, the Land use/land cover raster might have valid land use codes of 1 through 30, so you could choose a *NoData* value of 9999. The value "nan" IS NOT a valid NoData value, and will produce an error when running models. You can check the *NoData* value by looking at the raster's Properties in a GIS.
 
@@ -218,6 +218,8 @@ Before running InVEST, it is necessary to format your data. Although subsequent 
 + Similarly, the amount of disk space that is used by the model is in proportion to the resolution of the input data. If the area of interest is large and/or uses rasters with small cell size, this will increase the amount of disk space required to store intermediate and final model results. If not enough disk space is available, the model will return an error.
 
 + Running the models with the input data files open in another program can cause errors. Ensure that the data files are not in use by another program to prevent data access issues.
+
++ It is recommended to store model inputs and outputs on a local hard drive, not in cloud storage. Running the models with input data files accessed online (not on a local drive) can cause errors.
 
 + Regional and Language options: Some language settings cause errors while running the models.  For example settings which use comma (,) for decimals instead of period (.) cause errors in the models.  To solve this change the computer's regional settings to English.
 

--- a/source/en/ndr.rst
+++ b/source/en/ndr.rst
@@ -272,12 +272,14 @@ The model has options to calculate nitrogen, phosphorus, or both. You must provi
     .. note::
        Loads are the sources of nutrients associated with each LULC class. This value is the total load from all sources. If you want to represent different levels of fertilizer application, you will need to create separate LULC classes, for example one class called "crops - high fertilizer use" a separate class called "crops - low fertilizer use" etc.
 
+    - :investspec:`ndr.ndr biophysical_table_path.columns.nut_load_type`
+
     .. note::
-       Data sources may provide loading values as either the amount of applied nutrient (e.g. fertilizer, livestock waste, atmospheric deposition); or as “extensive” measures of contaminants, which are empirical values representing the contribution of a parcel to the nutrient budget (e.g. nutrient export running off urban areas, crops, etc.) In the case of having applied nutrient values, they should be corrected for the nutrient retention provided by the pixel itself, using the application rate and retention efficiency value (*eff_n* or *eff_p*) for that land cover type:
+       Data sources may provide loading values as either the amount of applied nutrient (e.g. fertilizer, livestock waste, atmospheric deposition); or as “extensive” measures of contaminants, which are empirical values representing the contribution of a parcel to the nutrient budget (e.g. nutrient export running off urban areas, crops, etc.) The two types are denoted *application-rate* and *measured-runoff* respectively in the biophysical table. In the case of having applied nutrient values, the model will correct for the nutrient retention provided by the pixel itself, using the application rate and retention efficiency value (*eff_n* or *eff_p*) for that land cover type:
 
        applied_nutrient * (1 - retention_efficiency)
 
-       For example, if the nitrogen application rate for an agricultural LULC class is 10 kg/ha/year, and the retention efficiency is 0.4, you should enter a value of 6.0 into the *n_load* column of the biophysical table. If you have "extensive"/nutrient export values, then you may use them directly in the biophysical table without correction.
+       For example, if the nitrogen application rate for an agricultural LULC class is 10 kg/ha/year, and the retention efficiency is 0.4, the model will adjust the value to 6.0. If you have "extensive"/nutrient export values, denoted as *measured-runoff* in the biophysical table, then the model will use these directly without correction.
 
     - :investspec:`ndr.ndr biophysical_table_path.columns.eff_[NUTRIENT]` The nutrient retention capacity for a given vegetation type is expressed as a proportion of the amount of nutrient from upslope. For example, high values (0.6 to 0.8) may be assigned to all natural vegetation types (such as forests, natural pastures, wetlands, or prairie), indicating that 60-80% of nutrient is retained.
 
@@ -424,11 +426,11 @@ Nutrient Load
 -------------
 For all water quality parameters (nutrient load, retention efficiency, and retention length), local literature should be consulted to derive site-specific values. The NatCap nutrient parameter database provides a non-exhaustive list of local references for nutrient loads and retention efficiencies: https://naturalcapitalproject.stanford.edu/sites/g/files/sbiybj9321/f/nutrient_db_0212.xlsx. Parn et al. (2012) and Harmel et al. (2007) provide a good review for agricultural land in temperate climate.
 
-Data sources may provide loading values as either the amount of applied nutrient (e.g. fertilizer, livestock waste, atmospheric deposition); or as “extensive” measures of contaminants, which are empirical values representing the contribution of a parcel to the nutrient budget (e.g. nutrient export running off urban areas, crops, etc.) In the case of having applied nutrient values, they should be corrected for the nutrient retention provided by the pixel itself, using the application rate and retention efficiency value (*eff_n* or *eff_p*) for that land cover type.
+Data sources may provide loading values as either the amount of applied nutrient (e.g. fertilizer, livestock waste, atmospheric deposition); or as “extensive” measures of contaminants, which are empirical values representing the contribution of a parcel to the nutrient budget (e.g. nutrient export running off urban areas, crops, etc.) In the case of having applied nutrient values, the model will correct for the nutrient retention provided by the pixel itself, using the application rate and retention efficiency value (*eff_n* or *eff_p*) for that land cover type.
 
 application_load * (1 - retention_efficiency)
 
-For example, if the nitrogen application rate for an agricultural LULC class is 10 kg/ha/year, and the retention efficiency is 0.4, you should enter a value of 6.0 into the *n_load* column of the biophysical table. If you have "extensive"/export values, then you may use them directly in the biophysical table without correction.
+For example, if the nitrogen application rate for an agricultural LULC class is 10 kg/ha/year, and the retention efficiency is 0.4, the model will adjust the value to 6.0. If you have "extensive"/export values, then you may use them directly in the biophysical table without correction.
 
 Examples of export coefficients (“extensive” measures) for the US can be found in the EPA PLOAD User’s Manual and in a review by Lin (2004). Note that the examples in the EPA guide are in lbs/ac/yr and must be converted to kg/ha/yr.
 


### PR DESCRIPTION
We're adding a new column in the NDR biophysical table, `nut_load_type` that can be either `application-rate | measured-runoff`. If it is `application-rate` the model will adjust the load value by `load_n * (1 - eff)`. So this is no longer something the user needs to do manually if they have application rate values.

The associated InVEST pr is here: https://github.com/natcap/invest/pull/1925. 