### PR TITLE
Changed output location of `stream.tif` for SWY and NDR

### DIFF
--- a/source/en/ndr.rst
+++ b/source/en/ndr.rst
@@ -333,6 +333,7 @@ In the file names below, "x" stands for either n (nitrogen) or p (phosphorus), d
       * *n_subsurface_export*: Total nitrogen export from the watershed by subsurface flow.[units kg/year] (Eq. :eq:`total_nutrient_export`)
       * *n_total_export*: Total nitrogen export from the watershed by surface and subsurface flow.[units kg/year] (Eq. :eq:`total_nutrient_export`)
 
+   * **stream.tif**: Stream network created from the DEM, with 0 representing land pixels, and 1 representing stream pixels (Eq. :eq:`ndr_stream`). Compare this layer with a real-world stream map, and adjust the Threshold Flow Accumulation so that this matches real-world streams as closely as possible.
    * **p_surface_export.tif**: A pixel level map showing how much phosphorus from each pixel eventually reaches the stream by surface flow. [units: kg/hectare/year] (Eq. :eq:`nutrient_export`)
    * **n_surface_export.tif**: A pixel level map showing how much nitrogen from each pixel eventually reaches the stream by surface flow. [units: kg/hectare/year] (Eq. :eq:`nutrient_export`)
    * **n_subsurface_export.tif**: A pixel level map showing how much nitrogen from each pixel eventually reaches the stream by subsurface flow. [units: kg/hectare/year] (Eq. :eq:`nutrient_export`)
@@ -356,7 +357,6 @@ In the file names below, "x" stands for either n (nitrogen) or p (phosphorus), d
    * **s_accumulation.tif**: Slope parameter for the IC equation found in the Nutrient Delivery section
    * **s_bar.tif**: Slope parameter for the IC equation found in the Nutrient Delivery section
    * **s_factor_inverse.tif**: Slope parameter for the IC equation found in the Nutrient Delivery section
-   * **stream.tif**: Stream network created from the DEM, with 0 representing land pixels, and 1 representing stream pixels (Eq. :eq:`ndr_stream`). Compare this layer with a real-world stream map, and adjust the Threshold Flow Accumulation so that this matches real-world streams as closely as possible.
    * **sub_load_n.tif**: Nitrogen loads for subsurface transport [units: kg/year]
    * **sub_ndr_n.tif**: Subsurface nitrogen NDR values
    * **surface_load_x.tif**: Above ground nutrient loads [units: kg/year]

--- a/source/en/seasonal_water_yield.rst
+++ b/source/en/seasonal_water_yield.rst
@@ -477,9 +477,11 @@ The resolution of the output rasters will be the same as the resolution of the D
 
  * **L_sum_[Suffix].tif** (type: raster; units: mm, but should be interpreted as relative values, not absolute): Map of :math:`L_{\text{sum}}` values, the flow through a pixel, contributed by all upslope pixels, that is available for evapotranspiration to downslope pixels
 
+ * **P_[Suffix].tif** (type: raster; units: mm/year): The total precipitation across all months on this pixel.
+
  * **QF_[Suffix].tif** (type: raster; units: mm): Map of annual quickflow (QF) values
 
- * **P_[Suffix].tif** (type: raster; units: mm/year): The total precipitation across all months on this pixel.
+ * **stream_[Suffix].tif** (type: raster): Stream network generated from the input DEM and Threshold Flow Accumulation. Values of 1 represent streams, values of 0 are non-stream pixels.
 
  * **Vri_[Suffix].tif** (type: raster; units: mm): Map of the values of recharge (contribution, positive or negative), to the total recharge
 
@@ -496,8 +498,6 @@ The resolution of the output rasters will be the same as the resolution of the D
  * **qf_1_[Suffix].tif...qf_12_[Suffix].tif** (type: raster; units: mm): Maps of monthly quickflow (1 = January... 12 = December)
 
  * **Si_[Suffix].tif** (type: raster; units: inches): Maximum potential retention, used in the calculation of quickflow. (Note that the unit is converted to mm in Eq. :eq:`(swy. 1)`).
-
- * **stream_[Suffix].tif** (type: raster): Stream network generated from the input DEM and Threshold Flow Accumulation. Values of 1 represent streams, values of 0 are non-stream pixels.
 
 
 Appendix 1: Data sources and guidance for parameter selection


### PR DESCRIPTION
Changed location where `stream.tif` is listed in the Interpreting Results section of the UG for both Seasonal Water Yield and Nutrient Delivery Ratio. Previously, this file was saved in the intermediate folder, and is now saved in the main output folder. 

Related Invest PR: [#1933](https://github.com/natcap/invest/pull/1933)
