### PR TITLE
SWY: Replace directory inputs with CSVs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git-lfs
-natcap.invest
+natcap.invest@git+https://github.com/natcap/invest@release/3.17.0
 pint
 setuptools_scm
 sphinx

--- a/source/en/seasonal_water_yield.rst
+++ b/source/en/seasonal_water_yield.rst
@@ -312,17 +312,19 @@ Data Needs
 
 - :investspec:`seasonal_water_yield.seasonal_water_yield results_suffix`
 
-- :investspec:`seasonal_water_yield.seasonal_water_yield precip_dir` It is strongly recommended to use the same precipitation layers that were used to create the evapotranspiration input rasters. If they are based on different sources of precipitation data, this introduces another source of uncertainty in the data, and the mismatch could affect the water balance components computed by the model.
+- :investspec:`seasonal_water_yield.seasonal_water_yield precip_raster_table` It is strongly recommended to use the same precipitation layers that were used to create the evapotranspiration input rasters. If they are based on different sources of precipitation data, this introduces another source of uncertainty in the data, and the mismatch could affect the water balance components computed by the model.
 
-  Contents:
+  Columns:
 
-  - :investspec:`seasonal_water_yield.seasonal_water_yield precip_dir.contents.[MONTH]`
+  - :investspec:`seasonal_water_yield.seasonal_water_yield precip_raster_table.columns.month`
+  - :investspec:`seasonal_water_yield.seasonal_water_yield precip_raster_table.columns.path`
 
-- :investspec:`seasonal_water_yield.seasonal_water_yield et0_dir` It is strongly recommended that the evapotranspiration input rasters be based on the same precipitation data as is input to the model. If they are based on different sources of precipitation data, this introduces another source of uncertainty in the data, and the mismatch could affect the water balance components computed by the model.
+- :investspec:`seasonal_water_yield.seasonal_water_yield et0_raster_table` It is strongly recommended that the evapotranspiration input rasters be based on the same precipitation data as is input to the model. If they are based on different sources of precipitation data, this introduces another source of uncertainty in the data, and the mismatch could affect the water balance components computed by the model.
 
-  Contents:
+  Columns:
 
-  - :investspec:`seasonal_water_yield.seasonal_water_yield et0_dir.contents.[MONTH]`
+  - :investspec:`seasonal_water_yield.seasonal_water_yield et0_raster_table.columns.month`
+  - :investspec:`seasonal_water_yield.seasonal_water_yield et0_raster_table.columns.path`
 
 - :investspec:`seasonal_water_yield.seasonal_water_yield dem_raster_path`
 


### PR DESCRIPTION
Update the User's Guide to reflect the changes in [InVEST PR #2126](https://github.com/natcap/invest/pull/2126), where we're replacing the `et0_dir` and `precip_dir` inputs with CSVs mapping month indexes to raster paths. 

Related: [InVEST Issue #2096](https://github.com/natcap/invest/issues/2096)