### PR TITLE
SWY: Update inputs for Chinese and Spanish translations

### DIFF
--- a/source/es/seasonal_water_yield.rst
+++ b/source/es/seasonal_water_yield.rst
@@ -240,17 +240,19 @@ Necesidades de datos
 
 - :investspec:`seasonal_water_yield.seasonal_water_yield results_suffix`
 
-- :investspec:`seasonal_water_yield.seasonal_water_yield precip_dir` Se recomienda encarecidamente utilizar las mismas capas de precipitación que se utilizaron para crear los rásteres de input de evapotranspiración. Si se basan en diferentes fuentes de datos de precipitación, se introduce otra fuente de incertidumbre en los datos, y el desajuste podría afectar a los componentes del balance hídrico calculados por el modelo.
+- :investspec:`seasonal_water_yield.seasonal_water_yield precip_raster_table` Se recomienda encarecidamente utilizar las mismas capas de precipitación que se utilizaron para crear los rásteres de input de evapotranspiración. Si se basan en diferentes fuentes de datos de precipitación, se introduce otra fuente de incertidumbre en los datos, y el desajuste podría afectar a los componentes del balance hídrico calculados por el modelo.
 
-  Contents:
+  Columnas:
 
-  - :investspec:`seasonal_water_yield.seasonal_water_yield precip_dir.contents.[MONTH]`
+  - :investspec:`seasonal_water_yield.seasonal_water_yield precip_raster_table.columns.month`
+  - :investspec:`seasonal_water_yield.seasonal_water_yield precip_raster_table.columns.path`
 
-- :investspec:`seasonal_water_yield.seasonal_water_yield et0_dir` Se recomienda encarecidamente que los rásteres de input de evapotranspiración se basen en los misnos datos de precipitación como input para el modelo. Si se basan en diferentes fuentes de datos de precipitación, se introduce otra fuente de incertidumbre en los datos, y el desajuste podría afectar a los componentes del balance hídrico calculados por el modelo.
+- :investspec:`seasonal_water_yield.seasonal_water_yield et0_raster_table` Se recomienda encarecidamente que los rásteres de input de evapotranspiración se basen en los misnos datos de precipitación como input para el modelo. Si se basan en diferentes fuentes de datos de precipitación, se introduce otra fuente de incertidumbre en los datos, y el desajuste podría afectar a los componentes del balance hídrico calculados por el modelo.
 
-  Contenido:
+  Columnas:
 
-  - :investspec:`seasonal_water_yield.seasonal_water_yield et0_dir.contents.[MONTH]`
+  - :investspec:`seasonal_water_yield.seasonal_water_yield et0_raster_table.columns.month`
+  - :investspec:`seasonal_water_yield.seasonal_water_yield et0_raster_table.columns.path`
 
 - :investspec:`seasonal_water_yield.seasonal_water_yield dem_raster_path`
 

--- a/source/zh/seasonal_water_yield.rst
+++ b/source/zh/seasonal_water_yield.rst
@@ -229,17 +229,19 @@
 
 - :investspec:`seasonal_water_yield.seasonal_water_yield results_suffix`
 
-- :investspec:`seasonal_water_yield.seasonal_water_yield precip_dir`
+- :investspec:`seasonal_water_yield.seasonal_water_yield precip_raster_table`
 
-  Contents:
+  列:
 
-  - :investspec:`seasonal_water_yield.seasonal_water_yield precip_dir.contents.[MONTH]`
+  - :investspec:`seasonal_water_yield.seasonal_water_yield precip_raster_table.columns.month`
+  - :investspec:`seasonal_water_yield.seasonal_water_yield precip_raster_table.columns.path`
 
-- :investspec:`seasonal_water_yield.seasonal_water_yield et0_dir`
+- :investspec:`seasonal_water_yield.seasonal_water_yield et0_raster_table`
 
-  内容:
+  列:
 
-  - :investspec:`seasonal_water_yield.seasonal_water_yield et0_dir.contents.[MONTH]`
+  - :investspec:`seasonal_water_yield.seasonal_water_yield et0_raster_table.columns.month`
+  - :investspec:`seasonal_water_yield.seasonal_water_yield et0_raster_table.columns.path`
 
 - :investspec:`seasonal_water_yield.seasonal_water_yield dem_raster_path`
 


### PR DESCRIPTION
In addition to updating the `et0_dir` and `precip_dir` keys on the English version of the UG, we also need to update the Chinese and Spanish translations to point to the new `et0_raster_table` and `precip_raster_table` inputs. 