### PR TITLE
Wind Energy: Require AOI, Land Polygon, Min and Max Distances

### DIFF
--- a/source/en/wind_energy.rst
+++ b/source/en/wind_energy.rst
@@ -377,30 +377,31 @@ Model Outputs
 Output Folder
 ^^^^^^^^^^^^^
 
- * `wind_energy_points.shp`: an ESRI Shapefile that summarizes the model outputs for each point. This shapefile contains only points that were determined to be valid locations based on ocean depth and (if distance parameters were provided) distance to shore. In addition to the fields provided in the input Wind Data CSV (long, lati, lam, k, ref), the following fields are provided:
-   * **ref_lam**: Weibull scale factor at the reference hub height at this point.
-   * **Dens_W/m2** (units: W/m^2): Power density at this point.
-   * **Harv_MWhr** (units: MWhr/yr): Predicted energy harvested from a wind farm centered on this point.
-   * **DepthVal** (units: meters): Ocean depth at this point.
-   * **DistVal** (units: meters): Distance to shore from this point. Included only if distance parameters were provided.
-   * **CO2_Tons** (units: metric tons/yr): Offset carbon emissions for a farm centered on this point. Included only if Valuation is run.
-   * **Level_Cost** (units: model input currency/kWhr): Energy price that would be required to set the present value of a farm centered on this point equal to zero. Included only if Valuation is run.
-   * **NPV** (units: model input currency): The net present value of a farm centered on this point. Included only if Valuation is run.
+* `wind_energy_points.shp`: an ESRI Shapefile that summarizes the model outputs for each point. This shapefile contains only points that were determined to be valid locations based on ocean depth and distance to shore. In addition to the fields provided in the input Wind Data CSV (long, lati, lam, k, ref), the following fields are provided:
+
+  * **ref_lam**: Weibull scale factor at the reference hub height at this point.
+  * **Dens_W/m2** (units: W/m^2): Power density at this point.
+  * **Harv_MWhr** (units: MWhr/yr): Predicted energy harvested from a wind farm centered on this point.
+  * **DepthVal** (units: meters): Ocean depth at this point.
+  * **DistVal** (units: meters): Distance to shore from this point.
+  * **CO2_Tons** (units: metric tons/yr): Offset carbon emissions for a farm centered on this point. Included only if Valuation is run.
+  * **Level_Cost** (units: model input currency/kWhr): Energy price that would be required to set the present value of a farm centered on this point equal to zero. Included only if Valuation is run.
+  * **NPV** (units: model input currency): The net present value of a farm centered on this point. Included only if Valuation is run.
 
 Intermediate Folder
 ^^^^^^^^^^^^^^^^^^^
 
- * `carbon_emissions_tons.tif`: a GeoTIFF raster file that represents tons of offset carbon emissions for a farm built centered on a pixel per year.
+* `carbon_emissions_tons.tif`: a GeoTIFF raster file that represents tons of offset carbon emissions for a farm built centered on a pixel per year.
 
- * `example_size_and_orientation_of_a_possible_wind_farm.shp`: an ESRI shapefile that represents the outer boundary of a sample windfarm. The position of this polygon is random and is meant to give the user a sense of scale of the potential wind farm.
+* `example_size_and_orientation_of_a_possible_wind_farm.shp`: an ESRI shapefile that represents the outer boundary of a sample windfarm. The position of this polygon is random and is meant to give the user a sense of scale of the potential wind farm.
 
- * `harvested_energy_MWhr_per_yr.tif`: a GeoTIFF raster file that represents the annual harvested energy from a farm centered on that pixel.
+* `harvested_energy_MWhr_per_yr.tif`: a GeoTIFF raster file that represents the annual harvested energy from a farm centered on that pixel.
 
- * `levelized_cost_price_per_kWh.tif`: a GeoTIFF raster file that represents the unit price of energy that would be required to set the present value of the farm centered at that pixel equal to zero. Values are given in the unit of currency used as model input.
+* `levelized_cost_price_per_kWh.tif`: a GeoTIFF raster file that represents the unit price of energy that would be required to set the present value of the farm centered at that pixel equal to zero. Values are given in the unit of currency used as model input.
 
- * `npv.tif`: a GeoTIFF raster file that represents the net present value of a farm centered on that pixel.
+* `npv.tif`: a GeoTIFF raster file that represents the net present value of a farm centered on that pixel.
 
- * `unmasked_wind_energy_points.shp`: an ESRI Shapefile that represents each wind data point in the input Wind Data Points CSV. This shapefile provides power density (W/m^2) values for all points, as well as annual harvested energy values and a field indicating whether or not a point was masked out due to depth or distance in the final output.
+* `unmasked_wind_energy_points.shp`: an ESRI Shapefile that represents each wind data point in the input Wind Data Points CSV. This shapefile provides power density (W/m^2) values for all points, as well as annual harvested energy values and a field indicating whether or not a point was masked out due to depth or distance in the final output.
 
 
 Appendix: Data Sources


### PR DESCRIPTION
Related InVEST PR: [#2135](https://github.com/natcap/invest/pull/2135)

This PR:
- Updates the Wind Energy docs where necessary to reflect that the AOI, Land Polygon, and Min and Max Distance inputs are always required. 
- Updates the `wind_energy_points.shp` output description to reflect that `DistVal` is no longer only conditionally provided. 
- Fixes the RST syntax in the Outputs section so that the vector fields will appear as a nested list rather than being lumped into one giant paragraph.

@rmgriffin I think these are the bare-minimum changes we'd need to include [InVEST PR #2135](https://github.com/natcap/invest/pull/2135) in the 3.17.0 release on ~October 7th. If you want to make more extensive changes before then to incorporate the new sample data, I'm happy to help you do so! 