### PR TITLE
add summary csv to carbon storage outputs (#229)

### DIFF
--- a/source/en/carbonstorage.rst
+++ b/source/en/carbonstorage.rst
@@ -148,7 +148,9 @@ Interpreting Results
 
 	* **c_change_bas_alt_[Suffix].tif**: Raster showing the difference in carbon stored between the alternate landscape and the baseline landscape. The values are in metric tons per hectare. In this map some values may be negative and some positive. Positive values indicate sequestered carbon, negative values indicate carbon that was lost.
 
-	* **npv_alt_[Suffix].tif**/:** Raster showing the economic value of carbon sequestered between the baseline and the alternate landscape dates. The units are in currency per hectare.
+	* **npv_alt_[Suffix].tif**: Raster showing the economic value of carbon sequestered between the baseline and the alternate landscape dates. The units are in currency per hectare.
+
+    * **raster_values_summary_[Suffix].csv**: CSV summarizing the total values, units, and filenames of the output rasters.
 
 * **[Workspace]\\intermediate_outputs** folder:
 

--- a/source/es/carbonstorage.rst
+++ b/source/es/carbonstorage.rst
@@ -154,7 +154,9 @@ Interpretación de los resultados
 
 	* **c_change_bas_alt_[Suffix].tif**: rásters que muestran la diferencia de carbono almacenado entre el paisaje futuro/REDD y el paisaje actual. Los valores se expresan en toneladas métricas por píxel. En este mapa algunos valores pueden ser negativos y otros positivos. Los valores positivos indican el carbono secuestrado, los negativos indican el carbono que se ha perdido.
 
-	* **npv_alt_[Suffix].tif**:** rásters que muestran el valor económico del carbono secuestrado entre las fechas del paisaje actual y el futuro/REDD. Las unidades son en moneda por píxel.
+	* **npv_alt_[Suffix].tif**: rásters que muestran el valor económico del carbono secuestrado entre las fechas del paisaje actual y el futuro/REDD. Las unidades son en moneda por píxel.
+
+    * **raster_values_summary_[Suffix].csv**: CSV summarizing the total values, units, and filenames of the output rasters.
 
 * **[Workspace]\\intermediate_outputs** carpeta:
 

--- a/source/zh/carbonstorage.rst
+++ b/source/zh/carbonstorage.rst
@@ -153,7 +153,10 @@ REDD 场景分析
 
 	* **c_change_bas_alt_[Suffix].tif**: 栅格显示未来/REDD景观与当前景观之间的碳储存差异。数值以公吨/像素为单位。在这个映射中，有些值可能是负数，有些可能是正数。正值表示封存的碳，负值表示流失的碳。
 
-	* **npv_alt_[Suffix].tif**:** 栅格显示当前和未来/REDD景观日期之间封存的碳的经济价值。单位是每像素的货币。
+	* **npv_alt_[Suffix].tif**: 栅格显示当前和未来/REDD景观日期之间封存的碳的经济价值。单位是每像素的货币。
+
+    * **raster_values_summary_[Suffix].csv**: CSV summarizing the total values, units, and filenames of the output rasters.
+
 * **[Workspace]\\intermediate_outputs** folder:
 
 	* **c_above_[Suffix].tif**:地上碳值的栅格，从碳库表映射到LULC。单位是公吨每像素。


### PR DESCRIPTION
Fixes #229 

Add the new raster values summary CSV to the list of model outputs. Related to [InVEST #2531](https://github.com/natcap/invest/issues/2531)